### PR TITLE
Add drawing functionality to PDF viewer

### DIFF
--- a/src/components/PdfViewer.tsx
+++ b/src/components/PdfViewer.tsx
@@ -28,6 +28,7 @@ const useStyles = makeStyles({
   },
   canvas: {
     border: "1px solid black",
+    position: "relative",
   },
   thumbnailWrapper: {
     display: "flex",
@@ -39,6 +40,10 @@ const useStyles = makeStyles({
     height: "auto",
     cursor: "pointer",
   },
+  rectangle: {
+    position: "absolute",
+    border: "2px solid",
+  },
 });
 
 const PdfViewer = () => {
@@ -48,6 +53,11 @@ const PdfViewer = () => {
   const [numPages, setNumPages] = useState<number | null>(null);
   const [scale, setScale] = useState(1.0);
   const [showThumbnails, setShowThumbnails] = useState(false);
+  const [rectangles, setRectangles] = useState([]);
+  const [drawing, setDrawing] = useState(false);
+  const [startX, setStartX] = useState(0);
+  const [startY, setStartY] = useState(0);
+  const [currentRect, setCurrentRect] = useState(null);
   const canvasRef = useRef(null);
 
   useEffect(() => {
@@ -56,6 +66,9 @@ const PdfViewer = () => {
       setPdf(loadedPdf);
       setNumPages(loadedPdf.numPages);
     });
+
+    const storedRectangles = JSON.parse(localStorage.getItem("rectangles") || "[]");
+    setRectangles(storedRectangles);
   }, []);
 
   useEffect(() => {
@@ -79,6 +92,63 @@ const PdfViewer = () => {
       window.removeEventListener("wheel", handleScroll);
     };
   }, [numPages]);
+
+  const handleMouseDown = (event) => {
+    if (event.ctrlKey && event.button === 0) {
+      setDrawing(true);
+      setStartX(event.nativeEvent.offsetX);
+      setStartY(event.nativeEvent.offsetY);
+      const newRect = {
+        x: event.nativeEvent.offsetX,
+        y: event.nativeEvent.offsetY,
+        width: 0,
+        height: 0,
+        color: "red",
+      };
+      setCurrentRect(newRect);
+    }
+  };
+
+  const handleMouseMove = (event) => {
+    if (drawing) {
+      const newRect = {
+        ...currentRect,
+        width: event.nativeEvent.offsetX - startX,
+        height: event.nativeEvent.offsetY - startY,
+      };
+      setCurrentRect(newRect);
+    }
+  };
+
+  const handleMouseUp = () => {
+    if (drawing) {
+      const finalRect = {
+        ...currentRect,
+        color: "green",
+      };
+      const newRectangles = [...rectangles, finalRect];
+      setRectangles(newRectangles);
+      localStorage.setItem("rectangles", JSON.stringify(newRectangles));
+      setDrawing(false);
+      setCurrentRect(null);
+    }
+  };
+
+  const handleKeyUp = (event) => {
+    if (event.key === "Control" && drawing) {
+      handleMouseUp();
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("mouseup", handleMouseUp);
+    window.addEventListener("keyup", handleKeyUp);
+
+    return () => {
+      window.removeEventListener("mouseup", handleMouseUp);
+      window.removeEventListener("keyup", handleKeyUp);
+    };
+  }, [drawing, currentRect]);
 
   interface RenderContext {
     canvasContext: CanvasRenderingContext2D;
@@ -159,7 +229,39 @@ const PdfViewer = () => {
           Toggle Thumbnails
         </Button>
       </div>
-      <canvas ref={canvasRef} className={styles.canvas} />
+      <div
+        ref={canvasRef}
+        className={styles.canvas}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+      >
+        <canvas />
+        {rectangles.map((rect, index) => (
+          <div
+            key={index}
+            className={styles.rectangle}
+            style={{
+              left: rect.x,
+              top: rect.y,
+              width: rect.width,
+              height: rect.height,
+              borderColor: rect.color,
+            }}
+          />
+        ))}
+        {currentRect && (
+          <div
+            className={styles.rectangle}
+            style={{
+              left: currentRect.x,
+              top: currentRect.y,
+              width: currentRect.width,
+              height: currentRect.height,
+              borderColor: currentRect.color,
+            }}
+          />
+        )}
+      </div>
       {showThumbnails && (
         <div className={styles.thumbnailWrapper}>
           {Array.from(new Array(numPages), (el, index) => (


### PR DESCRIPTION
Add functionality to draw rectangles on the document and store coordinates in Local Storage.

* Add state variables for drawing rectangles and storing coordinates.
* Add event listeners for mouse events to handle drawing rectangles.
* Add logic to store rectangle coordinates in Local Storage.
* Add logic to retrieve rectangle coordinates from Local Storage on load.
* Add logic to render stored rectangles on the document.

